### PR TITLE
Fix: Salir del script si falla la obtención de códigos de estación en…

### DIFF
--- a/modules/HopuWSprocessor.py
+++ b/modules/HopuWSprocessor.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from modules.environAPI_client.environClient import APIClass
 import os
 import json
+import sys
 
 cliente = APIClass()
 
@@ -33,6 +34,10 @@ class HopuWSprocessor:
         else:
             logger.error(f"Respuesta incorrecta del servidor: {respuesta['status_code']}")
             self.dict_estaciones = None
+
+        if self.dict_estaciones is None:
+            logger.critical("No se pudieron obtener los códigos de las estaciones para HopuWSprocessor. Saliendo.")
+            sys.exit(1)
 
     """
     def on_connect(self, client, userdata, flags, rc):

--- a/modules/IFAPAMetos.py
+++ b/modules/IFAPAMetos.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 import os
 import pytz
+import sys
 
 cliente = APIClass()
 
@@ -40,6 +41,10 @@ class IFAPAMetos:
         else:
             logger.error(f"Respuesta incorrecta del servidor: {respuesta['status_code']}")
             self.dict_estaciones = None
+
+        if self.dict_estaciones is None:
+            logger.critical("No se pudieron obtener los códigos de las estaciones para IFAPAMetos. Saliendo.")
+            sys.exit(1)
 
     """
     def on_connect(self, client, userdata, flags, rc):

--- a/modules/ModdedHopuWSprocessor.py
+++ b/modules/ModdedHopuWSprocessor.py
@@ -4,6 +4,7 @@ from modules.environAPI_client.environClient import APIClass
 
 import os
 import json
+import sys
 
 cliente = APIClass()
 
@@ -33,6 +34,10 @@ class ModdedHopuWSprocessor:
         else:
             logger.error(f"Respuesta incorrecta del servidor: {respuesta['status_code']}")
             self.dict_estaciones = None
+
+        if self.dict_estaciones is None:
+            logger.critical("No se pudieron obtener los códigos de las estaciones para ModdedHopuWSprocessor. Saliendo.")
+            sys.exit(1)
 
     """
     def on_connect(self, client, userdata, flags, rc):


### PR DESCRIPTION
… la inicialización

Impide errores 'NoneType' en on_message al asegurar que los procesadores no se inicien sin la configuración esencial de las estaciones.

Si la obtención de self.dict_estaciones falla durante __init__ en HopuWSprocessor, ModdedHopuWSprocessor o IFAPAMetos, el script ahora registrará un error crítico y llamará a sys.exit(1). Esto permite que Docker reinicie el contenedor para un nuevo intento.