### PR TITLE
Add Docker setup for project deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install git and any other needed packages
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Copy the entrypoint script into the container
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Make the entrypoint script executable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# Default command (can be overridden by docker-compose or run command)
+# This will be the command executed by the entrypoint script after cloning and installing dependencies
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# Título del Proyecto (Reemplaza con el título real de tu proyecto)
+
+(Añade aquí una breve descripción de tu proyecto en una o dos frases.)
+
+Este proyecto está configurado para ejecutarse dentro de un contenedor Docker. La contenerización se encarga de clonar el repositorio del proyecto, instalar las dependencias y ejecutar la aplicación.
+
+## Prerrequisitos
+
+Antes de comenzar, asegúrate de cumplir con los siguientes requisitos:
+*   **Docker**: Necesitas tener Docker instalado en tu sistema. [Guía de Instalación](https://docs.docker.com/get-docker/)
+*   **Docker Compose**: Necesitas Docker Compose. Normalmente se incluye con Docker Desktop para Windows y Mac, pero los usuarios de Linux pueden necesitar instalarlo por separado. [Guía de Instalación](https://docs.docker.com/compose/install/)
+*   **Git**: Aunque el contenedor se encarga de la clonación, Git es útil para gestionar los archivos de configuración del proyecto (como este README, Dockerfile, etc.) si estás contribuyendo a la configuración.
+
+## Cómo Empezar
+
+Para poner en marcha el proyecto, sigue estos pasos:
+
+1.  **Clona este repositorio de configuración (si aún no lo has hecho):**
+    ```bash
+    git clone <url_a_este_repositorio_de_configuracion>
+    cd <directorio_del_repositorio_de_configuracion>
+    ```
+
+2.  **Crea un archivo `.env`:**
+    En el directorio raíz de esta configuración (junto a `docker-compose.yml`), crea un archivo llamado `.env`. Este archivo almacenará tus credenciales sensibles y configuración. Añade el siguiente contenido, reemplazando los valores de ejemplo con tus datos reales:
+
+    ```env
+    GITHUB_API_KEY=tu_token_de_acceso_personal_de_github
+    REPO_URL=https://github.com/tu_usuario/tu_repositorio_del_proyecto.git
+    ```
+    *   `GITHUB_API_KEY`: Un Token de Acceso Personal (PAT) de GitHub con permisos para clonar el repositorio de destino. El script `entrypoint.sh` dentro del contenedor Docker lo utiliza para clonar/actualizar el código de tu proyecto privado. [Crear un PAT](https://docs.github.com/es/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+    *   `REPO_URL`: La URL HTTPS del repositorio Git que contiene el código de tu aplicación. Para este proyecto, será `https://github.com/manuelespinosa/mqttWS.git`.
+
+3.  **Construye y ejecuta la aplicación usando Docker Compose:**
+    Abre tu terminal en el directorio que contiene el archivo `docker-compose.yml` y ejecuta:
+    ```bash
+    docker-compose up --build -d
+    ```
+    *   `--build`: Esta opción le indica a Docker Compose que construya la imagen antes de iniciar el contenedor. Deberías usarla la primera vez o cuando hayas realizado cambios en el `Dockerfile` o `entrypoint.sh`.
+    *   `-d`: Esta opción ejecuta los contenedores en modo detached (en segundo plano).
+
+4.  **Accediendo a la aplicación:**
+    (Añade aquí instrucciones sobre cómo acceder a tu aplicación. Por ejemplo, si es un servidor web, especifica el puerto, ej.: `Abre tu navegador y navega a http://localhost:8000`). Si es un script que procesa datos, explica cómo verificar su salida o logs.
+
+    Para ver los logs del contenedor en ejecución:
+    ```bash
+    docker-compose logs -f app
+    ```
+
+## Cómo Funciona
+
+*   **`Dockerfile`**: Define el entorno para tu aplicación. Comienza desde una imagen base de Python, instala `git`, y configura un script `entrypoint.sh` para gestionar el código de la aplicación.
+*   **`entrypoint.sh`**: Este script se ejecuta cada vez que se inicia el contenedor.
+    *   Comprueba si el código de la aplicación desde `REPO_URL` está presente en el directorio `/app`.
+    *   Si no está presente, clona el repositorio usando tu `GITHUB_API_KEY`.
+    *   Si está presente, intenta obtener los últimos cambios (`git pull`).
+    *   Luego instala/actualiza las dependencias de Python desde un archivo `requirements.txt` (se espera que esté en tu repositorio de aplicación clonado).
+    *   Finalmente, ejecuta el comando principal de la aplicación (por defecto es `python main.py`).
+*   **`docker-compose.yml`**: Orquesta la construcción y ejecución del contenedor Docker.
+    *   Construye la imagen usando el `Dockerfile`.
+    *   Pasa `GITHUB_API_KEY` y `REPO_URL` del archivo `.env` como variables de entorno al contenedor.
+    *   Utiliza un **bind mount** para mapear el directorio `./app` en tu máquina anfitriona al directorio `/app` dentro del contenedor. Esto significa que:
+        *   El código clonado por `entrypoint.sh` dentro del contenedor aparecerá en el directorio `./app` en tu anfitrión.
+        *   Cualquier cambio que hagas al código en `./app` en tu anfitrión se reflejará dentro del contenedor (aunque para Python, podría ser necesario reiniciar el proceso de la aplicación dentro del contenedor para que los cambios surtan efecto, a menos que tu aplicación se recargue automáticamente).
+        *   El código persiste en tu anfitrión incluso si el contenedor se detiene o se elimina.
+*   **Directorio `./app`**: Este directorio se crea en tu máquina anfitriona (si no existe) cuando se ejecuta `docker-compose up`. El script `entrypoint.sh` clonará/actualizará el código de tu aplicación en este directorio (a través del bind mount a `/app` en el contenedor).
+
+## Estructura del Proyecto (de esta configuración)
+
+```
+.
+├── .env                # Almacena tu API key y la URL del repo (tú lo creas)
+├── Dockerfile          # Instrucciones para construir la imagen Docker
+├── docker-compose.yml  # Define cómo ejecutar el contenedor Docker
+├── entrypoint.sh       # Script para clonar/actualizar el repo y ejecutar la app
+├── README.md           # Este archivo
+└── app/                # Este directorio se creará y poblará con el código
+                        # de tu aplicación cuando el contenedor se inicie.
+```
+
+## Detener la Aplicación
+
+Para detener la aplicación y eliminar los contenedores, ejecuta:
+```bash
+docker-compose down
+```
+Si también deseas eliminar el volumen (que en esta configuración significa principalmente el código en `./app` si no quieres conservarlo, aunque el bind mount significa que está en tu sistema anfitrión de todos modos), puedes añadir la opción `-v`:
+```bash
+docker-compose down -v
+```
+Sin embargo, dado que `./app` es un bind mount desde tu anfitrión, `docker-compose down -v` no eliminará el directorio `./app` en tu anfitrión. Deberías eliminarlo manualmente si lo deseas.
+
+## Personalización Adicional
+
+*   **Comando de la Aplicación**: El comando por defecto para ejecutar tu aplicación es `python main.py` (definido como `CMD` en el `Dockerfile`). Si tu aplicación necesita un comando diferente, puedes:
+    *   Modificar la línea `CMD` en el `Dockerfile` y reconstruir la imagen (`docker-compose up --build -d`).
+    *   Sobrescribir el comando en `docker-compose.yml` añadiendo/descomentando una directiva `command:` bajo el servicio `app`.
+*   **Puertos**: Si tu aplicación escucha en un puerto de red (por ejemplo, un servidor web), descomenta y ajusta la sección `ports` en `docker-compose.yml`.
+*   **Versión de Python**: Para cambiar la versión de Python, modifica la línea `FROM` en el `Dockerfile` para usar una etiqueta de imagen de Python diferente (por ejemplo, `python:3.8-slim`, `python:3.10`) y reconstruye.
+*   **Dependencias del Sistema**: Si tu aplicación requiere bibliotecas de sistema adicionales, añade su instalación a la línea `RUN apt-get update && apt-get install -y ...` en el `Dockerfile` y reconstruye.
+
+(Añade cualquier otra sección relevante, ej.: Contribuciones, Licencia, Solución de Problemas)
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: my_python_app
+    restart: unless-stopped
+    environment:
+      - GITHUB_API_KEY=${GITHUB_API_KEY} # Must be set in .env file or system environment
+      - REPO_URL=${REPO_URL}             # Must be set in .env file or system environment
+    volumes:
+      - ./app:/app # Bind mount for the application code
+    # If you need to expose any ports from your application:
+    # ports:
+    #   - "8000:8000"
+    # The command to run can be overridden here if needed,
+    # otherwise it defaults to CMD in Dockerfile (python main.py)
+    # command: ["python", "your_app_script.py"]
+
+# To use this docker-compose.yml:
+# 1. Create a .env file in the same directory with:
+#    GITHUB_API_KEY=your_github_api_key_here
+#    REPO_URL=https://github.com/your_username/your_repository.git
+# 2. Run 'docker-compose up -d --build'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Check for required environment variables
+if [ -z "$GITHUB_API_KEY" ]; then
+  echo "Error: GITHUB_API_KEY environment variable is not set."
+  exit 1
+fi
+
+if [ -z "$REPO_URL" ]; then
+  echo "Error: REPO_URL environment variable is not set."
+  exit 1
+fi
+
+# Construct the authenticated repository URL
+# Assuming REPO_URL is in the format https://github.com/user/repo.git
+AUTH_REPO_URL=$(echo "$REPO_URL" | sed "s|https://|https://$GITHUB_API_KEY@|")
+
+# Target directory for cloning
+CLONE_DIR="/app"
+
+# Ensure the target directory exists
+mkdir -p "$CLONE_DIR"
+cd "$CLONE_DIR"
+
+# Check if the .git directory exists to determine if repo is already cloned
+if [ -d ".git" ]; then
+  echo "Repository already cloned. Attempting to pull latest changes..."
+  # Stash any local changes
+  git stash || echo "No local changes to stash or git stash failed."
+  # Pull the latest changes
+  git pull --rebase origin $(git rev-parse --abbrev-ref HEAD) || (echo "Git pull failed. Attempting to recover..." && git rebase --abort && git stash pop || echo "Could not recover automatically.")
+  # Attempt to pop the stash if it exists and has content
+  if git stash show > /dev/null; then
+    git stash pop || echo "Failed to pop stash. Manual intervention may be required if there were important local changes."
+  fi
+else
+  echo "Cloning repository..."
+  # Clone the repository. Use --depth 1 for a shallow clone if full history isn't needed.
+  # Using a temporary directory for cloning to avoid issues with non-empty /app if bind-mounted
+  TEMP_CLONE_DIR=$(mktemp -d)
+  git clone --quiet "$AUTH_REPO_URL" "$TEMP_CLONE_DIR"
+  # Move contents to /app, excluding .git if it's already there from a previous failed attempt
+  # but we want the .git from the new clone.
+  # Using rsync to handle this more robustly.
+  rsync -av --remove-source-files "$TEMP_CLONE_DIR/." "$CLONE_DIR/"
+  rm -rf "$TEMP_CLONE_DIR"
+  cd "$CLONE_DIR" # Ensure we are in the app directory
+fi
+
+# Install/update dependencies if requirements.txt exists
+if [ -f "requirements.txt" ]; then
+  echo "Installing/updating dependencies from requirements.txt..."
+  pip install --no-cache-dir -r requirements.txt
+else
+  echo "requirements.txt not found. Skipping dependency installation."
+fi
+
+echo "Starting application..."
+# Execute the command passed to the docker run or docker-compose
+exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+paho-mqtt
+requests
+pytz


### PR DESCRIPTION
This commit introduces a Docker-based setup to facilitate the deployment of the application.

Key components added:
- Dockerfile: Defines the image for the application, including Python environment and git.
- entrypoint.sh: Script to clone/pull the application repository on container start and install dependencies.
- docker-compose.yml: Orchestrates the service, managing environment variables and volume mounts.
- README.md: Provides instructions on how to use the Docker setup, including prerequisites and configuration (now in Spanish).
- requirements.txt: Lists Python dependencies (paho-mqtt, requests, pytz) - this file should exist in the target application repository.

The setup uses a bind mount for `./app` to persist the cloned application code on the host and expects `GITHUB_API_KEY` and `REPO_URL` to be provided via an .env file for cloning the application repository.